### PR TITLE
Fix reproducing complexity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+queue-app

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
            github.com/spf13/afero            \
            github.com/yandex/pandora
     
-    go build tnt_queue_gun.go
+    GOOS=linux GOARCH=amd64 go build tnt_queue_gun.go
     ```
 2. Если go нет в системе, но есть докер:
     ```shell
@@ -38,7 +38,7 @@ $ cartridge build
 Для запуска инстансов кластера:
 
 ```shell
-$ cartridge start
+$ cartridge start -d
 ```
 
 Конфигурацию кластера выполним скриптом bootstrap.lua:

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -7,4 +7,4 @@ RUN go get github.com/tarantool/go-tarantool \
            github.com/spf13/afero            \
            github.com/yandex/pandora
 
-RUN go build tnt_queue_gun.go
+RUN GOOS=linux GOARCH=amd64 go build tnt_queue_gun.go

--- a/tnt_queue_load.yaml
+++ b/tnt_queue_load.yaml
@@ -3,8 +3,8 @@ pools:
     gun:
         type: tnt_queue_gun
         target:
-            - localhost:3301
-            - localhost:3302
+            - localhost:3301 # replace by host.docker.internal:3301 if you use mac
+            - localhost:3302 # replace by host.docker.internal:3302 if you use mac
         user: admin
         pass: queue-app-cluster-cookie
     ammo:
@@ -22,4 +22,4 @@ pools:
         to: 25000
     startup:
         type: once
-        times: 1000
+        times: 10


### PR DESCRIPTION
* build golang binary only for linux. It would avoid users from unsupported binary error in the yandex-tank docker container.
* reduce the workers count load option (startup.times) in ``tnt_queue_load.yaml``. Now a bigger part of users could run test.
* add .dockerignore file, where "queue-app" path is added. It helps to avoid a situation, when user started cartridge app and then wanted to build binary by docker (./build.sh), but got the "socker not supported" error.